### PR TITLE
Fix timestamp lock cleanup

### DIFF
--- a/entrypoint/entrypoint.sh
+++ b/entrypoint/entrypoint.sh
@@ -443,6 +443,8 @@ update_timestamp_file() {
   exec 300>"$lock_file"
   if ! flock -n 300; then
     log "flock not supported or lock acquisition failed. Falling back to directory-based locking."
+    exec 300>&-
+    rm -f "$lock_file"
     use_flock=false
   fi
 
@@ -451,6 +453,8 @@ update_timestamp_file() {
     _write_timestamp_file "$temp_file" "$timestamp_file"
     # Release the lock
     flock -u 300
+    exec 300>&-
+    rm -f "$lock_file"
   else
     # Fallback to directory-based locking using mkdir
     if mkdir "$lock_dir" 2>/dev/null; then

--- a/tests/test_odoo_config.py
+++ b/tests/test_odoo_config.py
@@ -107,15 +107,17 @@ class TestOdooConfig(unittest.TestCase):
     @patch('os.replace')
     @patch('os.fdopen')
     @patch('tempfile.mkstemp')
+    @patch('os.fsync')
     @patch('fcntl.flock')
     @patch('builtins.open', new_callable=mock_open)
     def test_write_config_lines(self, mock_open_file: MagicMock, mock_flock: MagicMock,
-                               mock_mkstemp: MagicMock, mock_fdopen: MagicMock,
-                               mock_replace: MagicMock) -> None:
+                               mock_fsync: MagicMock, mock_mkstemp: MagicMock,
+                               mock_fdopen: MagicMock, mock_replace: MagicMock) -> None:
         """Test writing config lines atomically."""
         lines = ['[options]\n', 'key=value\n']
         mock_mkstemp.return_value = (3, '/tmp/tmpfile')
         mock_tmp = MagicMock()
+        mock_tmp.fileno.return_value = 3
         mock_fdopen.return_value.__enter__.return_value = mock_tmp
         odoo_config.write_config_lines(lines)
         mock_mkstemp.assert_called_once()


### PR DESCRIPTION
## Summary
- clean `.lock` files when writing timestamp
- patch `test_write_config_lines` to properly mock `os.fsync`

## Testing
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683e554b4ce08328a8693e8e990a409f