### PR TITLE
Fix config generation race

### DIFF
--- a/entrypoint/entrypoint.sh
+++ b/entrypoint/entrypoint.sh
@@ -1185,7 +1185,9 @@ main() {
     }
   fi
 
-  # Ensure odoo.conf exists with sane defaults after initialization or wait
+  # Ensure odoo.conf exists before upgrade.
+  # Other helpers like set_admin_password will create the file later,
+  # but upgrade_odoo runs first and requires it to exist.
   odoo-config --defaults || {
     log "Failed to ensure Odoo configuration defaults."
     exit 1

--- a/entrypoint/entrypoint.sh
+++ b/entrypoint/entrypoint.sh
@@ -1185,6 +1185,12 @@ main() {
     }
   fi
 
+  # Ensure odoo.conf exists with sane defaults after initialization or wait
+  odoo-config --defaults || {
+    log "Failed to ensure Odoo configuration defaults."
+    exit 1
+  }
+
   check_scaffolded_semaphore
   upgrade_odoo
   set_admin_password


### PR DESCRIPTION
## Summary
- ensure `odoo.conf` is created with defaults even when init is skipped

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68410fd2fcc08328b56f1abab0c862f3